### PR TITLE
stop scatterplot resizing axes to filtered data on attribute selection

### DIFF
--- a/js/distogramViewBB.js
+++ b/js/distogramViewBB.js
@@ -250,9 +250,11 @@
             this.listenTo (CLMSUI.vent, "linkMetadataUpdated", function (columns) {
                 //console.log ("HELLO", arguments);
                 var newOptions = columns.map (function (column) {
-                    return {id: column, label: column, decimalPlaces: 2, matchLevel: false, linkFunc: function (c) {
-                        return c.meta ? [c.meta[column]] : [];
-                    }};
+                    return {
+                        id: column, label: column, decimalPlaces: 2, matchLevel: false, 
+                        linkFunc: function (c) {return c.meta ? [c.meta[column]] : []; },
+                        unfilteredLinkFunc: function (c) {return c.meta ? [c.meta[column]] : []; },
+                    };
                 });
                 //console.log ("NEW OPTIONS", newOptions);
                 

--- a/js/modelUtils.js
+++ b/js/modelUtils.js
@@ -736,17 +736,61 @@ CLMSUI.modelUtils = {
     },
     
     attributeOptions: [
-        {linkFunc: function (link) { return [link.filteredMatches_pp.length]; }, id: "MatchCount", label: "Cross-Link Match Count", decimalPlaces: 0},
-        {linkFunc: function (link) { return link.filteredMatches_pp.map (function (m) { return m.match.score; }); }, id: "Score", label: "Match Score", decimalPlaces: 2, matchLevel: true},
-        {linkFunc: function (link) { return link.filteredMatches_pp.map (function (m) { return m.match.precursorMZ; }); }, id: "MZ", label: "Match Precursor m/z", decimalPlaces: 4, matchLevel: true},
-        {linkFunc: function(link) { return link.filteredMatches_pp.map (function (m) { return m.match.precursorCharge; }); }, id: "Charge", label: "Match Precursor Charge (z)", decimalPlaces: 0,  matchLevel: true},
-        {linkFunc: function(link) { return link.filteredMatches_pp.map (function (m) { return m.match.calc_mass; }); }, id: "CalcMass", label: "Match Calculated Mass (m)", decimalPlaces: 4, matchLevel: true},
-        {linkFunc: function(link) { return link.filteredMatches_pp.map (function (m) { return m.match.massError(); }); }, id: "MassError", label: "Match Mass Error", decimalPlaces: 4, matchLevel: true},
-        {linkFunc: function(link) { return link.filteredMatches_pp.map (function (m) { return Math.min (m.pepPos[0].length, m.pepPos[1].length); }); }, id: "SmallPeptideLen", label: "Match Smaller Peptide Length (AA)", decimalPlaces: 0, matchLevel: true},
-        {linkFunc: function(link) { return link.filteredMatches_pp.map (function (m) { var p = m.match.precursor_intensity; return isNaN(p) ? undefined : p; }); }, id: "PrecursorIntensity", label: "Match Precursor Intensity", decimalPlaces: 2, matchLevel: true},
-        {linkFunc: function(link) { return link.filteredMatches_pp.map (function (m) { return m.match.elution_time_start; }); }, id: "ElutionTimeStart", label: "Elution Time Start", decimalPlaces: 2, matchLevel: true},
-        {linkFunc: function(link) { return link.filteredMatches_pp.map (function (m) { return m.match.elution_time_end; }); }, id: "ElutionTimeEnd", label: "Elution Time End", decimalPlaces: 2, matchLevel: true},
-        {linkFunc: function (link, option) { return link.isLinearLink() ? [] : [this.model.getSingleCrosslinkDistance (link, null, null, option)]; }, id: "Distance", label: "Cα-Cα Distance (Å)", decimalPlaces: 2, maxVal: 90,}, 
+        {
+            linkFunc: function (link) { return [link.filteredMatches_pp.length]; },
+            unfilteredLinkFunc: function (link) { return [link.matches_pp.length]; },
+            id: "MatchCount", label: "Cross-Link Match Count", decimalPlaces: 0
+        },
+        {
+            linkFunc: function (link) { return link.filteredMatches_pp.map (function (m) { return m.match.score; }); }, 
+            unfilteredLinkFunc: function (link) { return link.matches_pp.map (function (m) { return m.match.score; }); },
+            id: "Score", label: "Match Score", decimalPlaces: 2, matchLevel: true
+        },
+        {
+            linkFunc: function (link) { return link.filteredMatches_pp.map (function (m) { return m.match.precursorMZ; }); }, 
+            unfilteredLinkFunc: function (link) { return link.matches_pp.map (function (m) { return m.match.precursorMZ; }); },
+            id: "MZ", label: "Match Precursor m/z", decimalPlaces: 4, matchLevel: true
+        },
+        {
+            linkFunc: function(link) { return link.filteredMatches_pp.map (function (m) { return m.match.precursorCharge; }); }, 
+            unfilteredLinkFunc: function (link) { return link.matches_pp.map (function (m) { return m.match.precursorCharge; }); },
+            id: "Charge", label: "Match Precursor Charge (z)", decimalPlaces: 0,  matchLevel: true
+        },
+        {
+            linkFunc: function(link) { return link.filteredMatches_pp.map (function (m) { return m.match.calc_mass; }); }, 
+            unfilteredLinkFunc: function (link) { return link.matches_pp.map (function (m) { return m.match.calc_mass; }); },
+            id: "CalcMass", label: "Match Calculated Mass (m)", decimalPlaces: 4, matchLevel: true
+        },
+        {
+            linkFunc: function(link) { return link.filteredMatches_pp.map (function (m) { return m.match.massError(); }); }, 
+            unfilteredLinkFunc: function (link) { return link.matches_pp.map (function (m) { return m.match.massError(); }); },
+            id: "MassError", label: "Match Mass Error", decimalPlaces: 4, matchLevel: true
+        },
+        {
+            linkFunc: function(link) { return link.filteredMatches_pp.map (function (m) { return Math.min (m.pepPos[0].length, m.pepPos[1].length); }); }, 
+            unfilteredLinkFunc: function (link) { return link.matches_pp.map (function (m) { return Math.min (m.pepPos[0].length, m.pepPos[1].length); }); },
+            id: "SmallPeptideLen", label: "Match Smaller Peptide Length (AA)", decimalPlaces: 0, matchLevel: true
+        },
+        {
+            linkFunc: function(link) { return link.filteredMatches_pp.map (function (m) { var p = m.match.precursor_intensity; return isNaN(p) ? undefined : p; }); }, 
+            unfilteredLinkFunc: function (link) { return link.matches_pp.map (function (m) { var p = m.match.precursor_intensity; return isNaN(p) ? undefined : p; }); },
+            id: "PrecursorIntensity", label: "Match Precursor Intensity", decimalPlaces: 2, matchLevel: true
+        },
+        {
+            linkFunc: function(link) { return link.filteredMatches_pp.map (function (m) { return m.match.elution_time_start; }); }, 
+            unfilteredLinkFunc: function (link) { return link.matches_pp.map (function (m) { return m.match.elution_time_start; }); },
+            id: "ElutionTimeStart", label: "Elution Time Start", decimalPlaces: 2, matchLevel: true
+        },
+        {
+            linkFunc: function(link) { return link.filteredMatches_pp.map (function (m) { return m.match.elution_time_end; }); }, 
+            unfilteredLinkFunc: function (link) { return link.matches_pp.map (function (m) { return m.match.elution_time_end; }); },
+            id: "ElutionTimeEnd", label: "Elution Time End", decimalPlaces: 2, matchLevel: true
+        },
+        {
+            linkFunc: function (link, option) { return link.isLinearLink() ? [] : [this.model.getSingleCrosslinkDistance (link, null, null, option)]; }, 
+            unfilteredLinkFunc: function (link, option) { return link.isLinearLink() ? [] : [this.model.getSingleCrosslinkDistance (link, null, null, option)]; },
+            id: "Distance", label: "Cα-Cα Distance (Å)", decimalPlaces: 2, maxVal: 90,
+        }, 
     ],
 };
 


### PR DESCRIPTION
- because then it can't show data that's bigger than the axis bounds when refiltered back in